### PR TITLE
Add support for Hikvision camera's and several fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,7 +89,7 @@ ipython_config.py
 #   However, in case of collaboration, if having platform-specific dependencies or dependencies
 #   having no cross-platform support, pipenv may install dependencies that don't work, or not
 #   install all needed dependencies.
-#Pipfile.lock
+Pipfile.lock
 
 # PEP 582; used by e.g. github.com/David-OConnor/pyflow
 __pypackages__/
@@ -127,3 +127,8 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# VSCode
+.vscode
+
+test.py

--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,17 @@
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[dev-packages]
+pylint = "*"
+autopep8 = "*"
+
+[packages]
+cryptography = "==2.8"
+pandas = "==0.25.3"
+requests = "*"
+fake-useragent = "*"
+
+[requires]
+python_version = "3.7"

--- a/pyezviz/DeviceSwitchType.py
+++ b/pyezviz/DeviceSwitchType.py
@@ -1,6 +1,6 @@
 from enum import Enum
 
-@unique
+# @unique
 class DeviceSwitchType(Enum):
     ALARM_TONE  = 1
     STREAM_ADAPTIVE = 2

--- a/pyezviz/camera.py
+++ b/pyezviz/camera.py
@@ -16,9 +16,9 @@ class PyEzvizError(Exception):
 class EzvizCamera(object):
     def __init__(self, client, serial):
         """Initialize the camera object."""
-        self._serial = serial
         self._client = client
-        
+        self._serial = serial
+
     def load(self):
         """Load object properties"""
         page_list = self._client.get_PAGE_LIST()
@@ -48,7 +48,10 @@ class EzvizCamera(object):
         self._switch = switches
 
         # load detection sensibility
-        self._detection_sensibility = self._client.get_detection_sensibility(self._serial)
+        if self._device["deviceCategory"] != "COMMON":
+            self._detection_sensibility = self._client.get_detection_sensibility(self._serial)
+        else:
+            self._detection_sensibility = None
 
         return True
 
@@ -63,11 +66,11 @@ class EzvizCamera(object):
             'status': self._device['status'],
             'device_sub_category': self._device['deviceSubCategory'],
 
-            'privacy': self._switch.get( DeviceSwitchType.SLEEP.value )['enable'],
-            'audio': self._switch.get( DeviceSwitchType.SOUND.value )['enable'],
-            'ir_led': self._switch.get( DeviceSwitchType.INFRARED_LIGHT.value )['enable'],
-            'state_led': self._switch.get(DeviceSwitchType.LIGHT.value )['enable'],
-            'follow_move': self._switch.get(DeviceSwitchType.MOBILE_TRACKING.value )['enable'],
+            'privacy': self.get_switch(DeviceSwitchType.SLEEP),
+            'audio': self.get_switch(DeviceSwitchType.SOUND),
+            'ir_led': self.get_switch(DeviceSwitchType.INFRARED_LIGHT),
+            'state_led': self.get_switch(DeviceSwitchType.LIGHT),
+            'follow_move': self.get_switch(DeviceSwitchType.MOBILE_TRACKING),
 
             'alarm_notify': bool(self._status[KEY_ALARM_NOTIFICATION]),
             'alarm_sound_mod': ALARM_SOUND_MODE[int(self._status['alarmSoundMode'])],
@@ -93,37 +96,50 @@ class EzvizCamera(object):
 
         return True
 
+
     def alarm_notify(self, enable):
         """Enable/Disable camera notification when movement is detected."""
         return self._client.data_report(self._serial, enable)
+
 
     def alarm_sound(self, sound_type):
         """Enable/Disable camera sound when movement is detected."""
         # we force enable = 1 , to make sound...
         return self._client.alarm_sound(self._serial, sound_type, 1)
 
+
     def alarm_detection_sensibility(self, sensibility):
         """Enable/Disable camera sound when movement is detected."""
         # we force enable = 1 , to make sound...
         return self._client.detection_sensibility(self._serial, sensibility)
 
+
     def switch_device_audio(self, enable=0):
         """Switch audio status on a device."""
-        return self._client.switch_status(self._serial, DeviceSwitchType.SOUND, enable)
+        return self._client.switch_status(self._serial, DeviceSwitchType.SOUND.value, enable)
+
 
     def switch_device_state_led(self, enable=0):
         """Switch audio status on a device."""
-        return self._client.switch_status(self._serial, DeviceSwitchType.LIGHT, enable)
+        return self._client.switch_status(self._serial, DeviceSwitchType.LIGHT.value, enable)
+
 
     def switch_device_ir_led(self, enable=0):
         """Switch audio status on a device."""
-        return self._client.switch_status(self._serial, DeviceSwitchType.INFRARED_LIGHT, enable)
+        return self._client.switch_status(self._serial, DeviceSwitchType.INFRARED_LIGHT.value, enable)
+
 
     def switch_privacy_mode(self, enable=0):
         """Switch privacy mode on a device."""
-        return self._client.switch_status(self._serial, DeviceSwitchType.SLEEP, enable)
+        return self._client.switch_status(self._serial, DeviceSwitchType.SLEEP.value, enable)
+
 
     def switch_follow_move(self, enable=0):
         """Switch follow move."""
-        return self._client.switch_status(self._serial, DeviceSwitchType.MOBILE_TRACKING, enable)
-        
+        return self._client.switch_status(self._serial, DeviceSwitchType.MOBILE_TRACKING.value, enable)
+
+
+    def get_switch(self, switch_type):
+        if switch_type.value in self._switch:
+            return self._switch.get(switch_type.value)['enable']
+        return None

--- a/pyezviz/camera.py
+++ b/pyezviz/camera.py
@@ -63,11 +63,11 @@ class EzvizCamera(object):
             'status': self._device['status'],
             'device_sub_category': self._device['deviceSubCategory'],
 
-            'privacy': self._switch.get( DeviceSwitchType.SLEEP )['enable'],
-            'audio': self._switch.get( DeviceSwitchType.SOUND )['enable'],
-            'ir_led': self._switch.get( DeviceSwitchType.INFRARED_LIGHT )['enable'],
-            'state_led': self._switch.get(DeviceSwitchType.LIGHT)['enable'],
-            'follow_move': self._switch.get(DeviceSwitchType.MOBILE_TRACKING)['enable'],
+            'privacy': self._switch.get( DeviceSwitchType.SLEEP.value )['enable'],
+            'audio': self._switch.get( DeviceSwitchType.SOUND.value )['enable'],
+            'ir_led': self._switch.get( DeviceSwitchType.INFRARED_LIGHT.value )['enable'],
+            'state_led': self._switch.get(DeviceSwitchType.LIGHT.value )['enable'],
+            'follow_move': self._switch.get(DeviceSwitchType.MOBILE_TRACKING.value )['enable'],
 
             'alarm_notify': bool(self._status[KEY_ALARM_NOTIFICATION]),
             'alarm_sound_mod': ALARM_SOUND_MODE[int(self._status['alarmSoundMode'])],
@@ -84,7 +84,7 @@ class EzvizCamera(object):
     def move(self, direction, speed=5):
         """Moves the camera."""
         if direction not in ['right','left','down','up']:
-            raise PyEzvizError("Invalid direction: %s ", command)
+            raise PyEzvizError("Invalid direction: %s ", direction)
 
         # launch the start command
         self._client.ptzControl(str(direction).upper(), self._serial, 'START', speed)

--- a/pyezviz/client.py
+++ b/pyezviz/client.py
@@ -9,6 +9,7 @@ from .camera import EzvizCamera
 # from pyezviz.camera import EzvizCamera
 
 COOKIE_NAME = "sessionId"
+COMMON_DEVICE_CATEGORY = "COMMON"
 CAMERA_DEVICE_CATEGORY = "IPC"
 DOORBELL_DEVICE_CATEGORY = "BDoorBell"
 
@@ -37,13 +38,8 @@ SWITCH_STATUS_URL = API_BASE_URI + API_ENDPOINT_SWITCH_STATUS
 DETECTION_SENSIBILITY_URL = API_BASE_URI + API_ENDPOINT_DETECTION_SENSIBILITY
 DETECTION_SENSIBILITY_GET_URL = API_BASE_URI + API_ENDPOINT_DETECTION_SENSIBILITY_GET
 
-
-
 DEFAULT_TIMEOUT = 10
 MAX_RETRIES = 3
-
-
-
 
 class PyEzvizError(Exception):
     pass
@@ -199,14 +195,16 @@ class EzvizClient(object):
         # get all devices
         devices = self.get_DEVICE()
         cameras = []
+        supported_categories = [COMMON_DEVICE_CATEGORY, CAMERA_DEVICE_CATEGORY, DOORBELL_DEVICE_CATEGORY]
 
         # foreach, launch a switchstatus for the proper serial
         for idx, device in enumerate(devices):
-            if devices[idx]['deviceCategory'] == CAMERA_DEVICE_CATEGORY:
-                camera = EzvizCamera(self, device['deviceSerial'])
-                camera.load()
-                cameras.append(camera.status())
-            if devices[idx]['deviceCategory'] == DOORBELL_DEVICE_CATEGORY:
+            if devices[idx]['deviceCategory'] in supported_categories:
+                # Add support for connected HikVision cameras
+                if devices[idx]['deviceCategory'] == COMMON_DEVICE_CATEGORY and not devices[idx]['hik']:
+                    next
+
+                # Create camera object
                 camera = EzvizCamera(self, device['deviceSerial'])
                 camera.load()
                 cameras.append(camera.status())

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,13 @@
-cryptography==2.8
-pandas==0.25.3
+certifi==2020.6.20
+chardet==3.0.4
+fake-useragent==0.1.11
+idna==2.10
+numpy==1.19.0
+pandas==1.0.5
+pyEzviz==0.1.5.5
+python-dateutil==2.8.1
+pytz==2020.1
+requests==2.24.0
+six==1.15.0
+urllib3==1.25.9
+uuid==1.30


### PR DESCRIPTION
- Camera category COMMON is supported, only if the attribute hik is true, so based on this Hikvision camera's connected to the EzViz Cloud are also supported on this way
- Several fixes in the camera and client to get it to work
- Module was crashing on camera's that didn't support some switches, introduced a new function which set it to None if not supported