### PR TITLE
Remove uuid from requirements.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,6 @@ setuptools.setup(
     install_requires=[
         'requests',
         'fake_useragent',
-        'uuid',
         'pandas'
     ],
     entry_points={


### PR DESCRIPTION
`uuid` has been part of the Python standard lib since Python 2.5. https://docs.python.org/2.7/library/uuid.html Installing this version breaks modern Python versions.