### PR TITLE
Add PTZ (x,y) control functions

### DIFF
--- a/pyezviz/__main__.py
+++ b/pyezviz/__main__.py
@@ -74,6 +74,20 @@ def main() -> Any:
         choices=range(1, 10),
     )
 
+    parser_camera_move_coords = subparsers_camera.add_parser("move_coords", help="Move the camera to the X,Y coordinates")
+    parser_camera_move_coords.add_argument(
+        "--x",
+        required=True,
+        help="The X coordinate to move the camera to",
+        type=float,
+    )
+    parser_camera_move_coords.add_argument(
+        "--y",
+        required=True,
+        help="The Y coordinate to move the camera to",
+        type=float,
+    )
+
     parser_camera_switch = subparsers_camera.add_parser(
         "switch", help="Change the status of a switch"
     )
@@ -249,6 +263,14 @@ def main() -> Any:
         if args.camera_action == "move":
             try:
                 camera.move(args.direction, args.speed)
+            except Exception as exp:  # pylint: disable=broad-except
+                print(exp)
+            finally:
+                client.close_session()
+
+        elif args.camera_action == "move_coords":
+            try:
+                camera.move_coordinates(args.x, args.y)
             except Exception as exp:  # pylint: disable=broad-except
                 print(exp)
             finally:

--- a/pyezviz/camera.py
+++ b/pyezviz/camera.py
@@ -177,6 +177,13 @@ class EzvizCamera:
 
         return True
 
+    def move_coordinates(self, x: float, y: float):
+        """Move camera to specified coordinates."""
+
+        self._client.ptz_control_coordinates(self._serial, x, y)
+
+        return True
+
     def alarm_notify(self, enable: int) -> bool:
         """Enable/Disable camera notification when movement is detected."""
         return self._client.set_camera_defence(self._serial, enable)

--- a/pyezviz/client.py
+++ b/pyezviz/client.py
@@ -522,15 +522,11 @@ class EzvizClient:
             self, serial: str, x: float, y: float
     ) -> Any:
         """PTZ Coordinate Move"""
-
-
-        print(f"client.ptz_control_coordinates({serial}, {x}, {y})")
-
         if 0 < x > 1:
             raise PyEzvizError(f"Invalid X coordinate: {x}: Should be between 0 and 1 inclusive")
 
-        # if 0 < y > 1:
-        #     raise PyEzvizError(f"Invalid Y coordinate: {y}: Should be between 0 and 1 inclusive")
+        if 0 < y > 1:
+            raise PyEzvizError(f"Invalid Y coordinate: {y}: Should be between 0 and 1 inclusive")
 
         try:
             req = self._session.post(

--- a/pyezviz/client.py
+++ b/pyezviz/client.py
@@ -35,6 +35,7 @@ API_ENDPOINT_SWITCH_DEFENCE_MODE = "/v3/userdevices/v1/group/switchDefenceMode"
 API_ENDPOINT_SWITCH_SOUND_ALARM = "/sendAlarm"
 API_ENDPOINT_SERVER_INFO = "/v3/configurations/system/info"
 API_ENDPOINT_LOGOUT = "/v3/users/logout/v2"
+API_ENDPOINT_PANORAMIC_DEVICES_OPERATION = "/v3/panoramicDevices/operation"
 
 
 class EzvizClient:
@@ -505,6 +506,41 @@ class EzvizClient:
                     "speed": speed,
                     "uuid": str(uuid4()),
                     "serial": serial,
+                },
+                headers={"sessionId": self._token["session_id"], "clientType": "1"},
+                timeout=self._timeout,
+            )
+
+            req.raise_for_status()
+
+        except requests.HTTPError as err:
+            raise HTTPError from err
+
+        return req.text
+
+    def ptz_control_coordinates(
+            self, serial: str, x: float, y: float
+    ) -> Any:
+        """PTZ Coordinate Move"""
+
+
+        print(f"client.ptz_control_coordinates({serial}, {x}, {y})")
+
+        if 0 < x > 1:
+            raise PyEzvizError(f"Invalid X coordinate: {x}: Should be between 0 and 1 inclusive")
+
+        # if 0 < y > 1:
+        #     raise PyEzvizError(f"Invalid Y coordinate: {y}: Should be between 0 and 1 inclusive")
+
+        try:
+            req = self._session.post(
+                "https://"
+                + self._token["api_url"]
+                + API_ENDPOINT_PANORAMIC_DEVICES_OPERATION,
+                data={
+                    "x": f"{x:.6f}",
+                    "y": f"{y:.6f}",
+                    "deviceSerial": serial,
                 },
                 headers={"sessionId": self._token["session_id"], "clientType": "1"},
                 timeout=self._timeout,


### PR DESCRIPTION
I've added controls for moving the camera using an undocumented endpoint, /v3/panoramicDevices/operation.

I've noticed while testing that the Y coordinate does nothing, but it does get sent when pressing on the panorama in the app, so I've added it in as well.

It's been tested and works correctly on my C6T camera, using the new command line `camera move_coords --x <x> --y <y>`.

<details>
  <summary>mitmproxy details of request / response implemented in this PR</summary>

![Screenshot_20211116_192628](https://user-images.githubusercontent.com/5726497/142045825-4eb476e6-3670-4fed-be46-3c6318d24d17.png)

![Screenshot_20211116_192655](https://user-images.githubusercontent.com/5726497/142045835-afed39e0-3c30-419f-bb8f-22f2d8ef3c01.png)
</details>

If you need me to change anything I'll be happy to do it.

-Joey

Fixes #53 