### PR TITLE
Do not disturb

### DIFF
--- a/pyezviz/__main__.py
+++ b/pyezviz/__main__.py
@@ -127,6 +127,18 @@ def main() -> Any:
         choices=range(0, 100),
     )
     parser_camera_alarm.add_argument(
+        '--do_not_disturb', 
+        required=False, 
+        help='\
+If alarm notifications are enabled in the EZViz app then movement normally causes a notification to be sent. \
+Enabling this feature stops these notifications, i.e. you are not to be disturbed even if movement occurs. \
+Care must be taken because do-not-disturb can not be reset using the mobile app. \
+No new notifications will be sent until do-not-disturb is disabled. \
+Movement is still recorded even if do-not-disturb is enabled.',
+        default=None, 
+        type=int, 
+        choices=[0,1] )    
+    parser_camera_alarm.add_argument(
         "--schedule", required=False, help="Schedule in json format *test*", type=str
     )
 
@@ -313,6 +325,8 @@ def main() -> Any:
                     camera.alarm_notify(args.notify)
                 if args.sensibility is not None:
                     camera.alarm_detection_sensibility(args.sensibility)
+                if args.do_not_disturb is not None:
+                    camera.do_not_disturb(args.do_not_disturb)
                 if args.schedule is not None:
                     camera.change_defence_schedule(args.schedule)
             except Exception as exp:  # pylint: disable=broad-except

--- a/pyezviz/__main__.py
+++ b/pyezviz/__main__.py
@@ -95,7 +95,7 @@ def main() -> Any:
         "--switch",
         required=True,
         help="Switch to switch",
-        choices=["audio", "ir", "state", "privacy", "sleep", "follow_move"],
+        choices=["audio", "ir", "state", "privacy", "sleep", "follow_move", "sound_alarm"],
     )
     parser_camera_switch.add_argument(
         "--enable",
@@ -312,6 +312,9 @@ Movement is still recorded even if do-not-disturb is enabled.',
                     camera.switch_sleep_mode(args.enable)
                 elif args.switch == "follow_move":
                     camera.switch_follow_move(args.enable)
+                elif args.switch == "sound_alarm":
+                    # Map 0|1 enable flog to operation type: 1 for off and 2 for on.
+                    camera.switch_sound_alarm(args.enable + 1)
             except Exception as exp:  # pylint: disable=broad-except
                 print(exp)
             finally:

--- a/pyezviz/camera.py
+++ b/pyezviz/camera.py
@@ -241,6 +241,10 @@ class EzvizCamera:
             self._serial, DeviceSwitchType.MOBILE_TRACKING.value, enable
         )
 
+    def switch_sound_alarm(self, enable: int = 0) -> bool:
+        """Sound alarm on a device."""
+        return self._client.sound_alarm(self._serial, enable)
+
     def change_defence_schedule(self, schedule: str, enable: int = 0) -> bool:
         """Change defence schedule. Requires json formatted schedules."""
         return self._client.api_set_defence_schedule(self._serial, schedule, enable)

--- a/pyezviz/camera.py
+++ b/pyezviz/camera.py
@@ -192,6 +192,12 @@ class EzvizCamera:
         # we force enable = 1 , to make sound...
         return self._client.alarm_sound(self._serial, sound_type, 1)
 
+    def do_not_disturb(self, enable: int) -> bool:
+        """Enable/Disable do not disturb; if motion triggers are normally sent to your device as a 
+           notification, then enabling this feature stops these notification being sent.
+           The alarm event is still recorded in the EzViz app as normal. """
+        return self._client.do_not_disturb(self._serial, enable)
+    
     def alarm_detection_sensibility(
         self, sensibility: int, type_value: int = 0
     ) -> bool | str:

--- a/pyezviz/client.py
+++ b/pyezviz/client.py
@@ -48,6 +48,8 @@ API_ENDPOINT_PANORAMIC_DEVICES_OPERATION = "/v3/panoramicDevices/operation"
 API_ENDPOINT_UPGRADE_DEVICE = "/v3/upgrades/v1/devices/"
 API_ENDPOINT_SEND_CODE = "/v3/sms/nologin/checkcode"
 
+API_ENDPOINT_V3_ALARMS = "/v3/alarms/"
+API_ENDPOINT_DO_NOT_DISTURB = "/1/nodisturb"
 
 class EzvizClient:
     """Initialize api client object."""
@@ -828,6 +830,55 @@ class EzvizClient:
             ) from err
 
         if json_output.get("meta").get("code") != 200:
+            raise PyEzvizError(
+                f"Could not set defence mode: Got {req.status_code} : {req.text})"
+            )
+
+        return True
+
+    def do_not_disturb(
+        self,
+        serial: str,
+        enable: int = 1,
+        max_retries: int = 0,
+    ) -> bool | str:
+        """Set detection sensibility."""
+        if max_retries > MAX_RETRIES:
+            raise PyEzvizError("Can't gather proper data. Max retries exceeded.")
+
+        try:
+            req = self._session.put(
+                "https://"
+                + self._token["api_url"]
+                + API_ENDPOINT_V3_ALARMS
+                + serial
+                + API_ENDPOINT_DO_NOT_DISTURB,
+                data={
+                    'enable': enable,
+                    'channelNo': "1",
+                    'deviceSerial': serial
+                },
+                timeout=self._timeout,
+            )
+            req.raise_for_status()
+
+        except requests.HTTPError as err:
+            if err.response.status_code == 401:
+                # session is wrong, need to re-log-in
+                self.login()
+                return self.do_not_disturb(
+                    serial, enable, max_retries + 1
+                )
+
+            raise HTTPError from err
+
+        try:
+            response_json = req.json()
+
+        except ValueError as err:
+            raise PyEzvizError("Could not decode response:" + str(err)) from err
+
+        if response_json.get("meta").get("code") != 200:
             raise PyEzvizError(
                 f"Could not set defence mode: Got {req.status_code} : {req.text})"
             )


### PR DESCRIPTION
I've implemented changes which allow a camera's do-not disturb mode to be set:

  If alarm notifications are enabled in the EZViz app then movement normally causes a notification to be sent. 
  Enabling this feature stops these notifications, i.e. you are not to be disturbed even if movement occurs. 
  Care must be taken because do-not-disturb can not be reset using the mobile app. 
  No new notifications will be sent until do-not-disturb is disabled. 
  Movement is still recorded even if do-not-disturb is enabled.

I've been using this feature to ensure movement is always recorded, but I only get notified when we're away from home.

I've also included a change which allows the command line interface to sound the alarm's siren.

Thanks

Andrew