### PR TITLE
fix #86 - support ssl in python 3.10

### DIFF
--- a/pyezviz/cas.py
+++ b/pyezviz/cas.py
@@ -57,7 +57,11 @@ class EzvizCAS:
 
         payload_end_padding = rand_hex.encode("latin1")
 
-        context = ssl.SSLContext(cert_reqs=ssl.CERT_NONE)
+        context = ssl.SSLContext(ssl.PROTOCOL_TLS)
+
+        context.set_ciphers(
+            "DEFAULT:!aNULL:!eNULL:!MD5:!3DES:!DES:!RC4:!IDEA:!SEED:!aDSS:!SRP:!PSK"
+        )
 
         # Create a TCP/IP socket
         my_socket = socket.create_connection(
@@ -125,7 +129,11 @@ class EzvizCAS:
             f"\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10"
         ).encode("latin1")
 
-        context = ssl.SSLContext(cert_reqs=ssl.CERT_NONE)
+        context = ssl.SSLContext(ssl.PROTOCOL_TLS)
+
+        context.set_ciphers(
+            "DEFAULT:!aNULL:!eNULL:!MD5:!3DES:!DES:!RC4:!IDEA:!SEED:!aDSS:!SRP:!PSK"
+        )
 
         # Create a TCP/IP socket
         my_socket = socket.create_connection(


### PR DESCRIPTION
fix #86 - python 3.10 breaks the library

In https://github.com/gwww/elkm1/compare/2.0.0...2.0.2# they fixed the ssl issue, I tested the same fix locally and it works great!

I would appreciate your CR @BaQs  @RenierM26