### PR TITLE
Use new change defence mode api instead of CAS request.

### DIFF
--- a/pyezviz/api_endpoints.py
+++ b/pyezviz/api_endpoints.py
@@ -39,6 +39,7 @@ API_ENDPOINT_ALARM_SOUND = "/alarm/sound"
 API_ENDPOINT_SWITCH_SOUND_ALARM = "/sendAlarm"
 API_ENDPOINT_DO_NOT_DISTURB = "/nodisturb"
 API_ENDPOINT_VIDEO_ENCRYPT = "encryptedInfo/risk"
+API_ENDPOINT_CHANGE_DEFENCE_STATUS = "changeDefenceStatusReq"
 
 API_ENDPOINT_CREATE_PANORAMIC = "/api/panoramic/devices/pics/collect"
 API_ENDPOINT_RETURN_PANORAMIC = "/api/panoramic/devices/pics"


### PR DESCRIPTION
- The EZVIZ app now makes use of an API endpoint to set Camera defence mode, add new Api and renamed old.

This should not cause any breaking changes.