### PR TITLE
Fix battery camera work mode + add cmd line arguments

### DIFF
--- a/pyezviz/__main__.py
+++ b/pyezviz/__main__.py
@@ -9,7 +9,7 @@ import pandas
 
 from .camera import EzvizCamera
 from .client import EzvizClient
-from .constants import DefenseModeType
+from .constants import DefenseModeType, BatteryCameraWorkMode
 from .exceptions import EzvizAuthVerificationCode
 from .mqtt import MQTTClient
 
@@ -152,6 +152,17 @@ Movement is still recorded even if do-not-disturb is enabled.",
     )
     parser_camera_alarm.add_argument(
         "--schedule", required=False, help="Schedule in json format *test*", type=str
+    )
+
+    parser_camera_select = subparsers_camera.add_parser(
+        "select", help="Change the value of a multi-value option (for on/off value, see 'switch' command)"
+    )
+
+    parser_camera_select.add_argument(
+        "--battery_work_mode",
+        required=False,
+        help="Change the work mode for battery powered camera",
+        choices=[mode.name for mode in BatteryCameraWorkMode if mode is not BatteryCameraWorkMode.UNKNOWN],
     )
 
     args = parser.parse_args()
@@ -350,6 +361,16 @@ Movement is still recorded even if do-not-disturb is enabled.",
                     camera.do_not_disturb(args.do_not_disturb)
                 if args.schedule is not None:
                     camera.change_defence_schedule(args.schedule)
+            except Exception as exp:  # pylint: disable=broad-except
+                print(exp)
+            finally:
+                client.close_session()
+            
+        elif args.camera_action == "select":
+            try:
+                if args.battery_work_mode is not None:
+                    camera.set_battery_camera_work_mode(getattr(BatteryCameraWorkMode, args.battery_work_mode))
+                
             except Exception as exp:  # pylint: disable=broad-except
                 print(exp)
             finally:

--- a/pyezviz/camera.py
+++ b/pyezviz/camera.py
@@ -252,3 +252,7 @@ class EzvizCamera:
     def change_defence_schedule(self, schedule: str, enable: int = 0) -> bool:
         """Change defence schedule. Requires json formatted schedules."""
         return self._client.api_set_defence_schedule(self._serial, schedule, enable)
+    
+    def set_battery_camera_work_mode(self, work_mode: BatteryCameraWorkMode) -> bool:
+        """Change work mode for battery powered camera device."""
+        return self._client.set_battery_camera_work_mode(self._serial, work_mode.value)

--- a/pyezviz/camera.py
+++ b/pyezviz/camera.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import datetime
 from typing import TYPE_CHECKING, Any
 
-from .constants import DeviceSwitchType, SoundMode
+from .constants import DeviceSwitchType, SoundMode, BatteryCameraWorkMode
 from .exceptions import PyEzvizError
 from .utils import fetch_nested_value, string_to_list
 
@@ -155,9 +155,9 @@ class EzvizCamera:
             "NightVision_Model": self.fetch_key(
                 ["STATUS", "optionals", "NightVision_Model"]
             ),
-            "batteryCameraWorkMode": self.fetch_key(
-                ["STATUS", "optionals", "workMode"]
-            ),
+            "battery_camera_work_mode": BatteryCameraWorkMode(
+                self.fetch_key(["STATUS", "optionals", "batteryCameraWorkMode"], -1)
+            ).name,
             "Alarm_AdvancedDetect": self.fetch_key(
                 ["STATUS", "optionals", "Alarm_AdvancedDetect", "type"]
             ),

--- a/pyezviz/client.py
+++ b/pyezviz/client.py
@@ -612,7 +612,7 @@ class EzvizClient:
         self,
         serial: str,
         value: Any,
-        key: str = "batteryCameraWorkMode",
+        key: str,
         max_retries: int = 0,
     ) -> bool:
         """Change value on device by setting key."""
@@ -663,7 +663,7 @@ class EzvizClient:
             ) from err
 
         if json_output["meta"]["code"] != 200:
-            raise PyEzvizError(f"Could not set camera work mode: Got {json_output})")
+            raise PyEzvizError(f"Could not set config key '${key}': Got {json_output})")
 
         return True
 

--- a/pyezviz/constants.py
+++ b/pyezviz/constants.py
@@ -365,6 +365,7 @@ class BatteryCameraWorkMode(Enum):
     BATTERY_WORK_MODE_POWER_SAVING = 0
     BATTERY_WORK_MODE_SUPER_POWER_SAVE = 3
     BATTERY_WORK_MODE_CUSTOM = 4
+    UNKNOWN = -1
 
 
 class DeviceCatagories(Enum):

--- a/pyezviz/constants.py
+++ b/pyezviz/constants.py
@@ -360,11 +360,11 @@ class DisplayMode(Enum):
 class BatteryCameraWorkMode(Enum):
     """Battery camera work modes."""
 
-    BATTERY_WORK_MODE_PLUGGED_IN = 2
-    BATTERY_WORK_MODE_HIGH_PERFORM = 1
-    BATTERY_WORK_MODE_POWER_SAVING = 0
-    BATTERY_WORK_MODE_SUPER_POWER_SAVE = 3
-    BATTERY_WORK_MODE_CUSTOM = 4
+    PLUGGED_IN = 2
+    HIGH_PERFORMANCE = 1
+    POWER_SAVE = 0
+    SUPER_POWER_SAVE = 3
+    CUSTOM = 4
     UNKNOWN = -1
 
 


### PR DESCRIPTION
Hello, 

This is my first PR on this repo so I hope I did it well.

I have a BC1C battery camera and I was happy to see what was added in June to set the battery work mode.

Unfortunately, due to a typo, the status was erroneous (`workMode` instead of `batteryCameraWorkMode`) so I fixed it and added some command line arguments to be able to set it.

I will submit a corresponding PR on [home-assistant](https://github.com/home-assistant/core) to add a Select entity for the battery-work-mode too.

Note: I did not change the `version` to `0.2.2.3` but I can do it if needed

@RenierM26 : Sorry to disturb you but I don't know if I have to tag you or not. If you can take a look at this PR when you have time, thanks in advance :)